### PR TITLE
Few updates for non-automated setups

### DIFF
--- a/README
+++ b/README
@@ -41,3 +41,8 @@ devices:
     conmux: mtp2k
     fastboot: abcdef2
     fastboot_set_active: true
+
+  - board: evb2k
+    console: /dev/ttyUSB0
+    fastboot: abcdef3
+    fastboot_set_active: true

--- a/device.c
+++ b/device.c
@@ -92,13 +92,15 @@ struct device *device_open(const char *board,
 	return NULL;
 
 found:
-	assert(device->open);
+	assert(device->open || device->console_dev);
 
 	device_lock(device);
 
-	device->cdb = device->open(device);
-	if (!device->cdb)
-		errx(1, "failed to open device controller");
+	if (device->open) {
+		device->cdb = device->open(device);
+		if (!device->cdb)
+			errx(1, "failed to open device controller");
+	}
 
 	if (device->console_dev)
 		console_open(device);
@@ -113,9 +115,8 @@ int device_power_on(struct device *device)
 	if (!device)
 		return 0;
 
-	assert(device->power_on);
-
-	device->power_on(device);
+	if (device->power_on)
+		device->power_on(device);
 
 	return 0;
 }
@@ -125,9 +126,8 @@ int device_power_off(struct device *device)
 	if (!device)
 		return 0;
 
-	assert(device->power_off);
-
-	device->power_off(device);
+	if (device->power_off)
+		device->power_off(device);
 
 	return 0;
 }

--- a/device_parser.c
+++ b/device_parser.c
@@ -141,7 +141,7 @@ static void parse_board(struct device_parser *dp)
 		}
 	}
 
-	if (!dev->board || !dev->serial || !dev->open) {
+	if (!dev->board || !dev->serial || !(dev->open || dev->console_dev)) {
 		fprintf(stderr, "device parser: insufficiently defined device\n");
 		exit(1);
 	}


### PR DESCRIPTION
Allow using cdba in non-automated setup (dummy power controller):
 - support dummy controller
 - enumerate fastboot devices during startup