### PR TITLE
Add two notifications from server side

### DIFF
--- a/cdba-server.c
+++ b/cdba-server.c
@@ -83,6 +83,8 @@ static void fastboot_opened(struct fastboot *fb, void *data)
 	const uint8_t one = 1;
 	struct msg *msg;
 
+	warnx("fastboot connection opened");
+
 	msg = alloca(sizeof(*msg) + 1);
 	msg->type = MSG_FASTBOOT_PRESENT;
 	msg->len = 1;

--- a/device.c
+++ b/device.c
@@ -178,6 +178,7 @@ void device_fastboot_flash_reboot(struct device *device)
 
 void device_boot(struct device *device, const void *data, size_t len)
 {
+	warnx("booting the board...");
 	if (device->set_active)
 		fastboot_set_active(device->fastboot, "a");
 	fastboot_download(device->fastboot, data, len);


### PR DESCRIPTION
To ease debugging connectivity vs bootloader vs early boot issues add two notifications on the server side:
 - when fastboot connection is opened
 - before sending fastboot commands to the device 