### PR TITLE
cdba: allow specifying symlink as a boot file

### DIFF
--- a/cdba.c
+++ b/cdba.c
@@ -660,7 +660,7 @@ int main(int argc, char **argv)
 		fastboot_file = argv[optind];
 		if (lstat(fastboot_file, &sb))
 			err(1, "unable to read \"%s\"", fastboot_file);
-		if (!S_ISREG(sb.st_mode))
+		if (!S_ISREG(sb.st_mode) && !S_ISLNK(sb.st_mode))
 			errx(1, "\"%s\" is not a regular file", fastboot_file);
 
 		request_select_board(board);


### PR DESCRIPTION
cdba will choke with 'is not a regular file' message if one specifies
symlink as a boot file argument. Support using symlinks as a boot file.

Signed-off-by: Dmitry Baryshkov <dbaryshkov@gmail.com>