### PR TITLE
cdba: Add support for cdba standalone client/server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ LDFLAGS := -ludev -lyaml
 CLIENT_SRCS := cdba.c cdba-client.c circ_buf.c
 CLIENT_OBJS := $(CLIENT_SRCS:.c=.o)
 
-SERVER_SRCS := cdba-server.c cdb_assist.c circ_buf.c conmux.c device.c device_parser.c fastboot.c alpaca.c console.c qcomlt_dbg.c
+SERVER_SRCS := cdba-server.c cdba-server-standalone.c cdb_assist.c circ_buf.c conmux.c device.c device_parser.c fastboot.c alpaca.c console.c qcomlt_dbg.c
 SERVER_OBJS := $(SERVER_SRCS:.c=.o)
 
 $(CLIENT): $(CLIENT_OBJS)

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,39 @@
 CLIENT := cdba
+CLIENT_STANDALONE := cdba-standalone
 SERVER := cdba-server
 
 .PHONY: all
 
-all: $(CLIENT) $(SERVER)
+all: $(CLIENT) $(CLIENT_STANDALONE) $(SERVER)
 
 CFLAGS := -Wall -g -O2
 LDFLAGS := -ludev -lyaml
 
-CLIENT_SRCS := cdba.c cdba-client.c circ_buf.c
+CLIENT_COMMON_SRCS := cdba-client.c circ_buf.c
+CLIENT_COMMON_OBJS := $(CLIENT_COMMON_SRCS:.c=.o)
+
+CLIENT_SRCS := cdba.c
 CLIENT_OBJS := $(CLIENT_SRCS:.c=.o)
+
+CLIENT_STANDALONE_SRCS := cdba-standalone.c
+CLIENT_STANDALONE_OBJS := $(CLIENT_STANDALONE_SRCS:.c=.o)
 
 SERVER_SRCS := cdba-server.c cdba-server-standalone.c cdb_assist.c circ_buf.c conmux.c device.c device_parser.c fastboot.c alpaca.c console.c qcomlt_dbg.c
 SERVER_OBJS := $(SERVER_SRCS:.c=.o)
 
-$(CLIENT): $(CLIENT_OBJS)
+$(CLIENT): $(CLIENT_OBJS) $(CLIENT_COMMON_OBJS)
+	$(CC) $(LDFLAGS) -o $@ $^
+
+$(CLIENT_STANDALONE): $(CLIENT_STANDALONE_OBJS) $(CLIENT_COMMON_OBJS)
 	$(CC) $(LDFLAGS) -o $@ $^
 
 $(SERVER): $(SERVER_OBJS)
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 clean:
-	rm -f $(CLIENT) $(CLIENT_OBJS) $(SERVER) $(SERVER_OBJS)
+	rm -f $(CLIENT) $(CLIENT_OBJS) $(CLIENT_STANDALONE) $(CLIENT_STANDALONE_OBJS) $(CLIENT_COMMON_OBJS) $(SERVER) $(SERVER_OBJS)
 
-install: $(CLIENT) $(SERVER)
+install: $(CLIENT) $(CLIENT_STANDALONE) $(SERVER)
 	install -D -m 755 $(CLIENT) $(DESTDIR)$(prefix)/bin/$(CLIENT)
+	install -D -m 755 $(CLIENT_STANDALONE) $(DESTDIR)$(prefix)/bin/$(CLIENT_STANDALONE)
 	install -D -m 755 $(SERVER) $(DESTDIR)$(prefix)/bin/$(SERVER)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: $(CLIENT) $(SERVER)
 CFLAGS := -Wall -g -O2
 LDFLAGS := -ludev -lyaml
 
-CLIENT_SRCS := cdba.c circ_buf.c
+CLIENT_SRCS := cdba.c cdba-client.c circ_buf.c
 CLIENT_OBJS := $(CLIENT_SRCS:.c=.o)
 
 SERVER_SRCS := cdba-server.c cdb_assist.c circ_buf.c conmux.c device.c device_parser.c fastboot.c alpaca.c console.c qcomlt_dbg.c

--- a/cdba-client.c
+++ b/cdba-client.c
@@ -1,0 +1,694 @@
+/*
+ * Copyright (c) 2016-2018, Linaro Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <sys/select.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <alloca.h>
+#include <err.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
+
+#include "cdba-client.h"
+#include "circ_buf.h"
+
+bool cdba_client_quit;
+
+struct list_head work_items = LIST_INIT(work_items);
+
+struct select_board {
+	struct work work;
+
+	const char *board;
+};
+
+static void select_board_fn(struct work *work, int ssh_stdin)
+{
+	struct select_board *board = container_of(work, struct select_board, work);
+	size_t blen = strlen(board->board) + 1;
+	struct msg *msg;
+	ssize_t n;
+
+	msg = alloca(sizeof(*msg) + blen);
+	msg->type = MSG_SELECT_BOARD;
+	msg->len = blen;
+	memcpy(msg->data, board->board, blen);
+
+	n = write(ssh_stdin, msg, sizeof(*msg) + blen);
+	if (n < 0)
+		err(1, "failed to send power on request");
+
+	free(work);
+}
+
+void cdba_client_request_select_board(const char *board)
+{
+	struct select_board *work;
+
+	work = malloc(sizeof(*work));
+	work->work.fn = select_board_fn;
+	work->board = board;
+
+	list_add(&work_items, &work->work.node);
+}
+
+static struct termios *tty_unbuffer(void)
+{
+	static struct termios orig_tios;
+	struct termios tios;
+	int ret;
+
+	ret = tcgetattr(STDIN_FILENO, &orig_tios);
+	if (ret < 0) {
+		/* stdin is not a tty */
+		if (errno == ENOTTY)
+			return NULL;
+		err(1, "unable to retrieve tty tios");
+	}
+
+	memcpy(&tios, &orig_tios, sizeof(struct termios));
+	tios.c_lflag &= ~(ICANON | ECHO | ISIG);
+	tios.c_iflag &= ~(ISTRIP | IGNCR | ICRNL | INLCR | IXOFF | IXON);
+	tios.c_cc[VTIME] = 0;
+	tios.c_cc[VMIN] = 1;
+	ret = tcsetattr(STDIN_FILENO, TCSANOW, &tios);
+	if (ret)
+		err(1, "unable to update tty tios");
+
+	return &orig_tios;
+}
+
+static void tty_reset(struct termios *orig_tios)
+{
+	int ret;
+
+	if (!orig_tios)
+		return;
+
+	tcflush(STDIN_FILENO, TCIFLUSH);
+	ret = tcsetattr(STDIN_FILENO, TCSANOW, orig_tios);
+	if (ret < 0)
+		warn("unable to reset tty tios");
+}
+
+static int fork_ssh(const char *host, const char *cmd, int *pipes)
+{
+	int piped_stdin[2];
+	int piped_stdout[2];
+	int piped_stderr[2];
+	pid_t pid;
+	int flags;
+	int i;
+
+	pipe(piped_stdin);
+	pipe(piped_stdout);
+	pipe(piped_stderr);
+
+	pid = fork();
+	switch(pid) {
+	case -1:
+		err(1, "failed to fork");
+	case 0:
+		dup2(piped_stdin[0], STDIN_FILENO);
+		dup2(piped_stdout[1], STDOUT_FILENO);
+		dup2(piped_stderr[1], STDERR_FILENO);
+
+		close(piped_stdin[0]);
+		close(piped_stdin[1]);
+
+		close(piped_stdout[0]);
+		close(piped_stdout[1]);
+
+		close(piped_stderr[0]);
+		close(piped_stderr[1]);
+
+		execl("/usr/bin/ssh", "ssh", host, cmd, NULL);
+		err(1, "launching ssh failed");
+	default:
+		close(piped_stdin[0]);
+		close(piped_stdout[1]);
+		close(piped_stderr[1]);
+	}
+
+	pipes[0] = piped_stdin[1];
+	pipes[1] = piped_stdout[0];
+	pipes[2] = piped_stderr[0];
+
+	for (i = 0; i < 3; i++) {
+		flags = fcntl(pipes[i], F_GETFL, 0);
+		fcntl(pipes[i], F_SETFL, flags | O_NONBLOCK);
+	}
+
+	return 0;
+}
+
+static int tty_callback(int *ssh_fds)
+{
+	static bool special;
+	struct msg hdr;
+	char buf[32];
+	ssize_t k;
+	ssize_t n;
+
+	n = read(STDIN_FILENO, buf, sizeof(buf));
+	if (n < 0)
+		return n;
+
+	for (k = 0; k < n; k++) {
+		if (buf[k] == 0x1) {
+			special = true;
+		} else if (special) {
+			switch (buf[k]) {
+			case 'q':
+				cdba_client_quit = true;
+				break;
+			case 'P':
+				hdr.type = MSG_POWER_ON;
+				hdr.len = 0;
+				write(ssh_fds[0], &hdr, sizeof(hdr));
+				break;
+			case 'p':
+				hdr.type = MSG_POWER_OFF;
+				hdr.len = 0;
+				write(ssh_fds[0], &hdr, sizeof(hdr));
+				break;
+			case 's':
+				hdr.type = MSG_STATUS_UPDATE;
+				hdr.len = 0;
+				write(ssh_fds[0], &hdr, sizeof(hdr));
+				break;
+			case 'V':
+				hdr.type = MSG_VBUS_ON;
+				hdr.len = 0;
+				write(ssh_fds[0], &hdr, sizeof(hdr));
+				break;
+			case 'v':
+				hdr.type = MSG_VBUS_OFF;
+				hdr.len = 0;
+				write(ssh_fds[0], &hdr, sizeof(hdr));
+				break;
+			case 'a':
+				hdr.type = MSG_CONSOLE;
+				hdr.len = 1;
+
+				write(ssh_fds[0], &hdr, sizeof(hdr));
+				write(ssh_fds[0], "\001", 1);
+				break;
+			case 'B':
+				hdr.type = MSG_SEND_BREAK;
+				hdr.len = 0;
+				write(ssh_fds[0], &hdr, sizeof(hdr));
+				break;
+			}
+
+			special = false;
+		} else {
+			hdr.type = MSG_CONSOLE;
+			hdr.len = 1;
+
+			write(ssh_fds[0], &hdr, sizeof(hdr));
+			write(ssh_fds[0], buf + k, 1);
+		}
+	}
+
+	return 0;
+}
+
+static void list_boards_fn(struct work *work, int ssh_stdin)
+{
+	struct msg msg;
+	ssize_t n;
+
+	msg.type = MSG_LIST_DEVICES;
+	msg.len = 0;
+
+	n = write(ssh_stdin, &msg, sizeof(msg));
+	if (n < 0)
+		err(1, "failed to send board list request");
+
+	free(work);
+}
+
+static void request_board_list(void)
+{
+	struct work *work;
+
+	work = malloc(sizeof(*work));
+	work->fn = list_boards_fn;
+
+	list_add(&work_items, &work->node);
+}
+
+struct board_info_request {
+	struct work work;
+	const char *board;
+};
+
+static void board_info_fn(struct work *work, int ssh_stdin)
+{
+	struct board_info_request *board = container_of(work, struct board_info_request, work);
+	size_t blen = strlen(board->board) + 1;
+	struct msg *msg;
+	ssize_t n;
+
+	msg = alloca(sizeof(*msg) + blen);
+	msg->type = MSG_BOARD_INFO;
+	msg->len = blen;
+	memcpy(msg->data, board->board, blen);
+
+	n = write(ssh_stdin, msg, sizeof(*msg) + blen);
+	if (n < 0)
+		err(1, "failed to send board info request");
+
+	free(work);
+}
+
+static void request_board_info(const char *board)
+{
+	struct board_info_request *work;
+
+	work = malloc(sizeof(*work));
+	work->work.fn = board_info_fn;
+	work->board = board;
+
+	list_add(&work_items, &work->work.node);
+}
+
+static void request_power_on_fn(struct work *work, int ssh_stdin)
+{
+	struct msg msg = { MSG_POWER_ON, };
+	ssize_t n;
+
+	n = write(ssh_stdin, &msg, sizeof(msg));
+	if (n < 0)
+		err(1, "failed to send power on request");
+}
+
+static void request_power_off_fn(struct work *work, int ssh_stdin)
+{
+	struct msg msg = { MSG_POWER_OFF, };
+	ssize_t n;
+
+	n = write(ssh_stdin, &msg, sizeof(msg));
+	if (n < 0)
+		err(1, "failed to send power off request");
+}
+
+void cdba_client_request_power_on(void)
+{
+	static struct work work = { request_power_on_fn };
+
+	list_add(&work_items, &work.node);
+}
+
+void cdba_client_request_power_off(void)
+{
+	static struct work work = { request_power_off_fn };
+
+	list_add(&work_items, &work.node);
+}
+
+static void handle_status_update(const void *data, size_t len)
+{
+	char *str = alloca(len + 1);
+
+	memcpy(str, data, len);
+	str[len] = '\n';
+
+	write(STDOUT_FILENO, str, len + 1);
+}
+
+static void handle_list_devices(const void *data, size_t len)
+{
+	char *board;
+
+	if (!len) {
+		cdba_client_quit = true;
+		return;
+	}
+
+	board = alloca(len + 1);
+	memcpy(board, data, len);
+	board[len] = '\n';
+	write(STDOUT_FILENO, board, len + 1);
+}
+
+static void handle_board_info(const void *data, size_t len)
+{
+	char *info;
+
+	info = alloca(len + 1);
+	memcpy(info, data, len);
+	info[len] = '\n';
+	write(STDOUT_FILENO, info, len + 1);
+
+	cdba_client_quit = true;
+}
+
+static bool received_power_off;
+static bool reached_timeout;
+
+static void handle_console(const void *data, size_t len)
+{
+	static int power_off_chars = 0;
+	const char *p = data;
+	int i;
+
+	for (i = 0; i < len; i++) {
+		if (*p++ == '~') {
+			if (power_off_chars++ == 19) {
+				received_power_off = true;
+				power_off_chars = 0;
+			}
+		} else {
+			power_off_chars = 0;
+		}
+	}
+
+	write(STDOUT_FILENO, data, len);
+}
+
+bool auto_power_on;
+
+static int handle_message(struct circ_buf *buf)
+{
+	struct msg *msg;
+	struct msg hdr;
+	size_t n;
+
+	for (;;) {
+		n = circ_peak(buf, &hdr, sizeof(hdr));
+		if (n != sizeof(hdr))
+			return 0;
+
+		if (CIRC_AVAIL(buf) < sizeof(*msg) + hdr.len)
+			return 0;
+
+		// fprintf(stderr, "avail: %zd hdr.len: %d\n", CIRC_AVAIL(buf), hdr.len);
+
+		msg = malloc(sizeof(*msg) + hdr.len);
+		circ_read(buf, msg, sizeof(*msg) + hdr.len);
+
+		switch (msg->type) {
+		case MSG_CONSOLE:
+			handle_console(msg->data, msg->len);
+			break;
+		case MSG_STATUS_UPDATE:
+			handle_status_update(msg->data, msg->len);
+			break;
+		case MSG_LIST_DEVICES:
+			handle_list_devices(msg->data, msg->len);
+			break;
+		case MSG_BOARD_INFO:
+			handle_board_info(msg->data, msg->len);
+			free(msg);
+			return -1;
+			break;
+		default:
+			if (cdba_handle_message(msg)) {
+				fprintf(stderr, "unk %d len %d\n", msg->type, msg->len);
+				free(msg);
+				return -1;
+			}
+		}
+
+		free(msg);
+	}
+
+	return 0;
+}
+
+static struct timeval get_timeout(int sec)
+{
+	struct timeval delta = { .tv_sec = sec };
+	struct timeval now;
+	struct timeval tv;
+
+	gettimeofday(&now, NULL);
+	timeradd(&now, &delta, &tv);
+
+	return tv;
+}
+
+void cdba_client_usage(void)
+{
+	extern const char *__progname;
+	cdba_usage(__progname);
+	fprintf(stderr, "usage: %s -i -b <board> -h <host>\n",
+			__progname);
+	fprintf(stderr, "usage: %s -l -h <host>\n",
+			__progname);
+	exit(1);
+}
+
+extern int verb;
+#define OPTS_MAX 512
+
+int cdba_client_main(int argc, char **argv, const char *extra_opts)
+{
+	bool power_cycle_on_timeout = true;
+	struct timeval timeout_inactivity_tv;
+	struct timeval timeout_total_tv;
+	struct termios *orig_tios;
+	const char *server_binary = "cdba-server";
+	int timeout_inactivity = 0;
+	int timeout_total = 600;
+	struct work *next;
+	struct work *work;
+	struct circ_buf recv_buf = { 0 };
+	const char *board = NULL;
+	const char *host = NULL;
+	struct timeval now;
+	struct timeval tv;
+	int power_cycles = 0;
+	int ssh_fds[3];
+	char buf[128];
+	fd_set rfds;
+	fd_set wfds;
+	ssize_t n;
+	int nfds;
+	int opt;
+	int ret;
+
+	char cdba_client_opts[OPTS_MAX];
+	snprintf(cdba_client_opts, OPTS_MAX - 1, "%sb:c:C:h:ilt:S:T:", extra_opts);
+	cdba_client_opts[OPTS_MAX - 1] = '\0';
+	while ((opt = getopt(argc, argv, cdba_client_opts)) != -1) {
+		switch (opt) {
+		case 'b':
+			board = optarg;
+			break;
+		case 'C':
+			power_cycle_on_timeout = false;
+			/* FALLTHROUGH */
+		case 'c':
+			power_cycles = atoi(optarg);
+			break;
+		case 'h':
+			host = optarg;
+			break;
+		case 'i':
+			verb = CDBA_INFO;
+			break;
+		case 'l':
+			verb = CDBA_LIST;
+			break;
+		case 'S':
+			server_binary = optarg;
+			break;
+		case 't':
+			timeout_total = atoi(optarg);
+			break;
+		case 'T':
+			timeout_inactivity = atoi(optarg);
+			break;
+		default:
+			if (cdba_handle_opt(opt, optarg))
+				cdba_client_usage();
+		}
+	}
+
+	if (!host)
+		cdba_client_usage();
+
+	switch (verb) {
+	case CDBA_LIST:
+		request_board_list();
+		break;
+	case CDBA_INFO:
+		if (!board)
+			cdba_client_usage();
+
+		request_board_info(board);
+		break;
+	default:
+		cdba_handle_verb(argc, argv, optind, board);
+		break;
+	}
+
+	ret = fork_ssh(host, server_binary, ssh_fds);
+	if (ret)
+		err(1, "failed to connect to \"%s\"", host);
+
+	orig_tios = tty_unbuffer();
+
+	timeout_total_tv = get_timeout(timeout_total);
+	timeout_inactivity_tv = get_timeout(timeout_inactivity);
+
+	while (!cdba_client_quit) {
+		if (received_power_off || reached_timeout) {
+			if (!power_cycles)
+				break;
+
+			if (reached_timeout && !power_cycle_on_timeout)
+				break;
+
+			printf("power cycle (%d left)\n", power_cycles);
+			fflush(stdout);
+
+			auto_power_on = true;
+			power_cycles--;
+			received_power_off = false;
+			reached_timeout = false;
+
+			cdba_client_request_power_off();
+
+			timeout_inactivity_tv = get_timeout(timeout_inactivity);
+		}
+
+		FD_ZERO(&rfds);
+		FD_SET(ssh_fds[1], &rfds);
+		FD_SET(ssh_fds[2], &rfds);
+		nfds = MAX(ssh_fds[1], ssh_fds[2]);
+
+		if (orig_tios) {
+			FD_SET(STDIN_FILENO, &rfds);
+
+			nfds = MAX(nfds, STDIN_FILENO);
+		}
+
+		FD_ZERO(&wfds);
+		if (!list_empty(&work_items))
+			FD_SET(ssh_fds[0], &wfds);
+
+		gettimeofday(&now, NULL);
+		if (timeout_inactivity && timercmp(&timeout_inactivity_tv, &timeout_total_tv, <)) {
+			timersub(&timeout_inactivity_tv, &now, &tv);
+		} else {
+			timersub(&timeout_total_tv, &now, &tv);
+		}
+
+		ret = select(nfds + 1, &rfds, &wfds, NULL, &tv);
+#if 0
+		printf("select: %d (%c%c%c)\n", ret, FD_ISSET(STDIN_FILENO, &rfds) ? 'X' : '-',
+						     FD_ISSET(ssh_fds[1], &rfds) ? 'X' : '-',
+						     FD_ISSET(ssh_fds[2], &rfds) ? 'X' : '-');
+#endif
+		if (ret < 0) {
+			err(1, "select");
+		} else if (ret == 0) {
+			if (timeout_inactivity && timercmp(&timeout_inactivity_tv, &timeout_total_tv, <))
+				warnx("timeout due to inactivity");
+			else
+				warnx("timeout reached");
+
+			reached_timeout = true;
+		}
+
+		if (FD_ISSET(STDIN_FILENO, &rfds))
+			tty_callback(ssh_fds);
+
+		if (FD_ISSET(ssh_fds[2], &rfds)) {
+			n = read(ssh_fds[2], buf, sizeof(buf));
+			if (!n) {
+				warnx("EOF on stderr");
+				break;
+			} else if (n < 0 && errno == EAGAIN) {
+			       continue;
+			} else if (n < 0) {
+				warn("received %zd on stderr", n);
+				break;
+			}
+
+			const char blue[] = "\033[94m";
+			const char reset[] = "\033[0m";
+
+			write(2, blue, sizeof(blue) - 1);
+			write(2, buf, n);
+			write(2, reset, sizeof(reset) - 1);
+		}
+
+		if (FD_ISSET(ssh_fds[1], &rfds)) {
+			ret = circ_fill(ssh_fds[1], &recv_buf);
+			if (ret < 0 && errno != EAGAIN) {
+				warn("received %d on stdout", ret);
+				break;
+			}
+
+			n = handle_message(&recv_buf);
+			if (n < 0)
+				break;
+
+			/* Reset inactivity timeout on activity */
+			if (timeout_inactivity)
+				timeout_inactivity_tv = get_timeout(timeout_inactivity);
+		}
+
+		if (FD_ISSET(ssh_fds[0], &wfds)) {
+			list_for_each_entry_safe(work, next, &work_items, node) {
+				list_del(&work->node);
+
+				work->fn(work, ssh_fds[0]);
+			}
+		}
+	}
+
+	close(ssh_fds[0]);
+	close(ssh_fds[1]);
+	close(ssh_fds[2]);
+
+	cdba_end();
+	wait(NULL);
+
+	tty_reset(orig_tios);
+
+	if (reached_timeout)
+		return cdba_client_reached_timeout();
+
+	return (cdba_client_quit || received_power_off) ? 0 : 1;
+}

--- a/cdba-client.h
+++ b/cdba-client.h
@@ -54,7 +54,7 @@ int cdba_handle_message(struct msg *msg);
 void cdba_end(void);
 
 void cdba_client_usage(void);
-void cdba_client_request_select_board(const char *board);
+void cdba_client_request_select_board(const char *board, uint8_t device_lock);
 void cdba_client_request_power_on(void);
 void cdba_client_request_power_off(void);
 int cdba_client_reached_timeout(void);

--- a/cdba-client.h
+++ b/cdba-client.h
@@ -54,7 +54,7 @@ int cdba_handle_message(struct msg *msg);
 void cdba_end(void);
 
 void cdba_client_usage(void);
-void cdba_client_request_select_board(const char *board, uint8_t device_lock);
+void cdba_client_request_select_board(const char *board, uint8_t device_standalone, uint8_t device_lock);
 void cdba_client_request_power_on(void);
 void cdba_client_request_power_off(void);
 int cdba_client_reached_timeout(void);

--- a/cdba-client.h
+++ b/cdba-client.h
@@ -1,0 +1,63 @@
+#ifndef __CDBA_CLIENT_H__
+#define __CDBA_CLIENT_H__
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "list.h"
+
+#define __packed __attribute__((packed))
+
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
+#define MAX(x, y) ((x) > (y) ? (x) : (y))
+
+struct work {
+        void (*fn)(struct work *work, int ssh_stdin);
+
+        struct list_head node;
+};
+
+struct msg {
+	uint8_t type;
+	uint16_t len;
+	uint8_t data[];
+} __packed;
+
+enum {
+	MSG_SELECT_BOARD = 1,
+	MSG_CONSOLE,
+	MSG_HARDRESET,
+	MSG_POWER_ON,
+	MSG_POWER_OFF,
+	MSG_FASTBOOT_REBOOT, // Messages handled by cdba.c
+	MSG_FASTBOOT_PRESENT,
+	MSG_FASTBOOT_DOWNLOAD,
+	MSG_STATUS_UPDATE,
+	MSG_VBUS_ON,
+	MSG_VBUS_OFF,
+	MSG_FASTBOOT_BOOT,
+	MSG_SEND_BREAK,
+	MSG_LIST_DEVICES,
+	MSG_BOARD_INFO,
+};
+
+#define MAX_CDBA_CLIENT_VERBS 2
+enum cdba_client_verbs {
+	CDBA_LIST = 0,
+	CDBA_INFO = 1,
+};
+
+void cdba_usage(const char *__progname);
+int cdba_handle_opt(int argc, const char *argv);
+void cdba_handle_verb(int argc, char **argv, int optind, const char *board);
+int cdba_handle_message(struct msg *msg);
+void cdba_end(void);
+
+void cdba_client_usage(void);
+void cdba_client_request_select_board(const char *board);
+void cdba_client_request_power_on(void);
+void cdba_client_request_power_off(void);
+int cdba_client_reached_timeout(void);
+int cdba_client_main(int argc, char **argv, const char *opts);
+
+#endif

--- a/cdba-server-standalone.c
+++ b/cdba-server-standalone.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2021, Linaro Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <limits.h>
+#include <unistd.h>
+#include <err.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include "cdba-client.h"
+#include "cdba-server.h"
+#include "cdba-server-standalone.h"
+
+#define UNIX_SOCKET_QUEUE 8
+
+static int cdba_server_standalone_data(int fd, void *data)
+{
+	struct device *device = data;
+
+	return 0;
+}
+
+static int cdba_server_standalone_create_channel(struct device *device)
+{
+	char socket_name[PATH_MAX];
+	struct sockaddr_un name;
+	int csocket;
+	int n;
+
+	n = snprintf(socket_name, sizeof(socket_name), "/tmp/cdba-%s.socket", device->board);
+	if (n >= sizeof(socket_name))
+		errx(1, "failed to build channel path");
+
+	csocket = socket(AF_LOCAL, SOCK_SEQPACKET, 0);
+	if (csocket == -1)
+		errx(1, "failed to create connection socket");
+
+	memset(&name, 0, sizeof(name));
+	name.sun_family = AF_UNIX;
+        strncpy(name.sun_path, socket_name, sizeof(name.sun_path) - 1);
+	name.sun_path[sizeof(name.sun_path) - 1] = '\0';
+
+	/**
+	 * When device is locked means that cdba-standalone client was inkoved to 
+	 * get console so the cdba-server expects commands (power on/off) from 
+	 * another client.
+	 */
+	if (device->locked) {
+		/* XXX: Remove socket, tried use of SO_REUSEADDR but socket needs
+		 * to be closed not useful when kill the process */
+		unlink(name.sun_path);
+
+		if (bind(csocket, (const struct sockaddr *) &name,
+		    sizeof(name)) == -1)
+			errx(1, "failed to bind connection socket");
+
+		if (listen(csocket, UNIX_SOCKET_QUEUE) == -1)
+			errx(1, "failed to bind connection socket");
+
+		watch_add_readfd(csocket, cdba_server_standalone_data, device);
+	} else {
+		if (connect(csocket, (const struct sockaddr *) &name,
+                          sizeof(name)) == -1)
+			errx(1, "failed to connect socket");
+	}
+
+	return csocket;
+}
+
+int cdba_server_standalone_create(struct device *device)
+{
+	device->standalone_channel = cdba_server_standalone_create_channel(device);
+	return device->standalone_channel;
+}
+
+
+int cdba_server_standalone_end(struct device *device)
+{
+	return close(device->standalone_channel);
+}

--- a/cdba-server-standalone.h
+++ b/cdba-server-standalone.h
@@ -1,0 +1,9 @@
+#ifndef __CDBA_SERVER_STANDALONE_H__
+#define __CDBA_SERVER_STANDALONE_H__
+
+#include "device.h"
+
+int cdba_server_standalone_create(struct device *device);
+int cdba_server_standalone_end(struct device *device);
+
+#endif

--- a/cdba-server-standalone.h
+++ b/cdba-server-standalone.h
@@ -6,4 +6,6 @@
 int cdba_server_standalone_create(struct device *device);
 int cdba_server_standalone_end(struct device *device);
 
+void cdba_server_standalone_device_power(struct device *device, bool on);
+
 #endif

--- a/cdba-server.c
+++ b/cdba-server.c
@@ -40,6 +40,7 @@
 #include <unistd.h>
 
 #include "cdba-server.h"
+#include "cdba-server-standalone.h"
 #include "circ_buf.h"
 #include "device.h"
 #include "device_parser.h"
@@ -201,14 +202,24 @@ static int handle_stdin(int fd, void *buf)
 			// fprintf(stderr, "hard reset\n");
 			break;
 		case MSG_POWER_ON:
-			device_power(selected_device, true);
+			if (selected_device->locked) {
+				device_power(selected_device, true);
+				invoke_reply(MSG_POWER_ON);
+			} else {
+				cdba_server_standalone_device_power(selected_device, true);
+				quit_invoked = true;
+			}
 
-			invoke_reply(MSG_POWER_ON);
 			break;
 		case MSG_POWER_OFF:
-			device_power(selected_device, false);
+			if (selected_device->locked) {
+				device_power(selected_device, false);
+				invoke_reply(MSG_POWER_OFF);
+			} else {
+				cdba_server_standalone_device_power(selected_device, false);
+				quit_invoked = true;
+			}
 
-			invoke_reply(MSG_POWER_OFF);
 			break;
 		case MSG_FASTBOOT_DOWNLOAD:
 			msg_fastboot_download(msg->data, msg->len);

--- a/cdba-standalone.c
+++ b/cdba-standalone.c
@@ -42,18 +42,19 @@
 
 #include "cdba-standalone.h"
 
+int lock = 1;
 int verb = -1;
 extern bool cdba_client_quit;
 
-static const char *cdba_standalone_opts = "a:p:";
+static const char *cdba_standalone_opts = "a:e:p:";
 
 void cdba_usage(const char *__progname)
 {
 	fprintf(stderr, "usage: %s -b <board> -h <host> [-t <timeout>] "
-			"[-T <inactivity-timeout>] <-a console>\n",
+			"[-T <inactivity-timeout>] <-a console> [-e on/off]\n",
 			__progname);
 	fprintf(stderr, "usage: %s -b <board> -h <host> [-t <timeout>] "
-			"[-T <inactivity-timeout>] <-p <on/off>>\n",
+			"[-T <inactivity-timeout>] <-p <on/off> [-e on/off]>\n",
 			__progname);
 }
 
@@ -66,6 +67,14 @@ int cdba_handle_opt(int opt, const char *optarg)
 		else
 			cdba_client_usage();
 
+		return 0;
+	case 'e':
+		if (strcmp(optarg, "on") == 0)
+			lock = 1;
+		else if (strcmp(optarg, "off") == 0)
+			lock = 0;
+		else
+			cdba_client_usage();
 		return 0;
 	case 'p':
 		if (strcmp(optarg, "on") == 0)
@@ -88,11 +97,11 @@ void cdba_handle_verb(int argc, char **argv, int optind, const char *board)
 
 	switch (verb) {
 	case CDBA_CONSOLE:
-		cdba_client_request_select_board(board, 1, 1);
+		cdba_client_request_select_board(board, 1, lock);
 		break;
 	case CDBA_POWER_ON:
 	case CDBA_POWER_OFF:
-		cdba_client_request_select_board(board, 1, 0);
+		cdba_client_request_select_board(board, 1, lock);
 		break;
 	}
 }

--- a/cdba-standalone.c
+++ b/cdba-standalone.c
@@ -133,5 +133,5 @@ int cdba_client_reached_timeout(void)
 
 int main(int argc, char **argv)
 {
-	cdba_client_main(argc, argv, cdba_standalone_opts);
+	return cdba_client_main(argc, argv, cdba_standalone_opts);
 }

--- a/cdba-standalone.c
+++ b/cdba-standalone.c
@@ -88,11 +88,11 @@ void cdba_handle_verb(int argc, char **argv, int optind, const char *board)
 
 	switch (verb) {
 	case CDBA_CONSOLE:
-		cdba_client_request_select_board(board, 1);
+		cdba_client_request_select_board(board, 1, 1);
 		break;
 	case CDBA_POWER_ON:
 	case CDBA_POWER_OFF:
-		cdba_client_request_select_board(board, 0);
+		cdba_client_request_select_board(board, 1, 0);
 		break;
 	}
 }

--- a/cdba-standalone.c
+++ b/cdba-standalone.c
@@ -45,6 +45,7 @@
 int lock = 1;
 int verb = -1;
 extern bool cdba_client_quit;
+static bool selected_board = false;
 
 static const char *cdba_standalone_opts = "a:e:p:";
 
@@ -112,6 +113,7 @@ int cdba_handle_message(struct msg *msg)
 
 	switch (msg->type) {
         case MSG_SELECT_BOARD:
+		selected_board = true;
 		switch (verb) {
 		case CDBA_CONSOLE:
 			break;
@@ -133,6 +135,8 @@ int cdba_handle_message(struct msg *msg)
 void cdba_end(void)
 {	if (verb == CDBA_CONSOLE)
 		printf("Waiting for ssh to finish\n");
+	else if (selected_board)
+		cdba_client_quit = true;
 }
 
 int cdba_client_reached_timeout(void)

--- a/cdba-standalone.c
+++ b/cdba-standalone.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2021, Linaro Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ * may be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <err.h>
+#include <errno.h>
+
+#include "cdba-standalone.h"
+
+int verb = -1;
+extern bool cdba_client_quit;
+
+static const char *cdba_standalone_opts = "a:p:";
+
+void cdba_usage(const char *__progname)
+{
+	fprintf(stderr, "usage: %s -b <board> -h <host> [-t <timeout>] "
+			"[-T <inactivity-timeout>] <-a console>\n",
+			__progname);
+	fprintf(stderr, "usage: %s -b <board> -h <host> [-t <timeout>] "
+			"[-T <inactivity-timeout>] <-p <on/off>>\n",
+			__progname);
+}
+
+int cdba_handle_opt(int opt, const char *optarg)
+{
+	switch (opt) {
+	case 'a':
+		if (strcmp(optarg, "console") == 0)
+			verb = CDBA_CONSOLE;
+		else
+			cdba_client_usage();
+
+		return 0;
+	case 'p':
+		if (strcmp(optarg, "on") == 0)
+			verb = CDBA_POWER_ON;
+		else if (strcmp(optarg, "off") == 0)
+			verb = CDBA_POWER_OFF;
+		else
+			cdba_client_usage();
+
+		return 0;
+	}
+
+	return 1;
+}
+
+void cdba_handle_verb(int argc, char **argv, int optind, const char *board)
+{
+	if (!board || verb == -1)
+		cdba_client_usage();
+
+	switch (verb) {
+	case CDBA_CONSOLE:
+		cdba_client_request_select_board(board, 1);
+		break;
+	case CDBA_POWER_ON:
+	case CDBA_POWER_OFF:
+		cdba_client_request_select_board(board, 0);
+		break;
+	}
+}
+
+int cdba_handle_message(struct msg *msg)
+{
+	int rc = 0;
+
+	switch (msg->type) {
+        case MSG_SELECT_BOARD:
+		switch (verb) {
+		case CDBA_CONSOLE:
+			break;
+		case CDBA_POWER_ON:
+			cdba_client_request_power_on();
+			break;
+		case CDBA_POWER_OFF:
+			cdba_client_request_power_off();
+			break;
+		}
+	case MSG_POWER_ON:
+	case MSG_POWER_OFF:
+		break;
+	}
+
+	return rc;
+}
+
+void cdba_end(void)
+{	if (verb == CDBA_CONSOLE)
+		printf("Waiting for ssh to finish\n");
+}
+
+int cdba_client_reached_timeout(void)
+{
+	return 2;
+}
+
+int main(int argc, char **argv)
+{
+	cdba_client_main(argc, argv, cdba_standalone_opts);
+}

--- a/cdba-standalone.h
+++ b/cdba-standalone.h
@@ -1,0 +1,17 @@
+#ifndef __CDBA_STANDALONE_H__
+#define __CDBA_STANDALONE_H__
+
+#include <stdbool.h>
+
+#include "cdba-client.h"
+#include "device.h"
+
+enum cdba_verbs {
+	CDBA_CONSOLE = MAX_CDBA_CLIENT_VERBS,
+	CDBA_POWER_ON,
+	CDBA_POWER_OFF,
+};
+
+void cdba_server_standalone_device_power(struct device *device, bool on);
+
+#endif // __CDBA_STANDALONE_H__

--- a/cdba.c
+++ b/cdba.c
@@ -213,5 +213,5 @@ int cdba_client_reached_timeout(void)
 
 int main(int argc, char **argv)
 {
-	cdba_client_main(argc, argv, cdba_opts);
+	return cdba_client_main(argc, argv, cdba_opts);
 }

--- a/cdba.c
+++ b/cdba.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, Linaro Ltd.
+ * Copyright (c) 2021, Linaro Ltd.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,331 +28,30 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#include <sys/select.h>
-#include <sys/stat.h>
-#include <sys/time.h>
+
+#include <stdbool.h>
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <alloca.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
 #include <err.h>
 #include <errno.h>
-#include <fcntl.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <termios.h>
-#include <unistd.h>
 
 #include "cdba.h"
-#include "circ_buf.h"
-#include "list.h"
 
-static bool quit;
+int verb = CDBA_BOOT;
+extern bool auto_power_on;
+extern struct list_head work_items;
+extern bool cdba_client_quit;
+
+static const char *cdba_opts = "R";
+
 static bool fastboot_repeat;
 static bool fastboot_done;
-
 static const char *fastboot_file;
-
-static struct termios *tty_unbuffer(void)
-{
-	static struct termios orig_tios;
-	struct termios tios;
-	int ret;
-
-	ret = tcgetattr(STDIN_FILENO, &orig_tios);
-	if (ret < 0) {
-		/* stdin is not a tty */
-		if (errno == ENOTTY)
-			return NULL;
-		err(1, "unable to retrieve tty tios");
-	}
-
-	memcpy(&tios, &orig_tios, sizeof(struct termios));
-	tios.c_lflag &= ~(ICANON | ECHO | ISIG);
-	tios.c_iflag &= ~(ISTRIP | IGNCR | ICRNL | INLCR | IXOFF | IXON);
-	tios.c_cc[VTIME] = 0;
-	tios.c_cc[VMIN] = 1;
-	ret = tcsetattr(STDIN_FILENO, TCSANOW, &tios);
-	if (ret)
-		err(1, "unable to update tty tios");
-
-	return &orig_tios;
-}
-
-static void tty_reset(struct termios *orig_tios)
-{
-	int ret;
-
-	if (!orig_tios)
-		return;
-
-	tcflush(STDIN_FILENO, TCIFLUSH);
-	ret = tcsetattr(STDIN_FILENO, TCSANOW, orig_tios);
-	if (ret < 0)
-		warn("unable to reset tty tios");
-}
-
-static int fork_ssh(const char *host, const char *cmd, int *pipes)
-{
-	int piped_stdin[2];
-	int piped_stdout[2];
-	int piped_stderr[2];
-	pid_t pid;
-	int flags;
-	int i;
-
-	pipe(piped_stdin);
-	pipe(piped_stdout);
-	pipe(piped_stderr);
-
-	pid = fork();
-	switch(pid) {
-	case -1:
-		err(1, "failed to fork");
-	case 0:
-		dup2(piped_stdin[0], STDIN_FILENO);
-		dup2(piped_stdout[1], STDOUT_FILENO);
-		dup2(piped_stderr[1], STDERR_FILENO);
-
-		close(piped_stdin[0]);
-		close(piped_stdin[1]);
-
-		close(piped_stdout[0]);
-		close(piped_stdout[1]);
-
-		close(piped_stderr[0]);
-		close(piped_stderr[1]);
-
-		execl("/usr/bin/ssh", "ssh", host, cmd, NULL);
-		err(1, "launching ssh failed");
-	default:
-		close(piped_stdin[0]);
-		close(piped_stdout[1]);
-		close(piped_stderr[1]);
-	}
-
-	pipes[0] = piped_stdin[1];
-	pipes[1] = piped_stdout[0];
-	pipes[2] = piped_stderr[0];
-
-	for (i = 0; i < 3; i++) {
-		flags = fcntl(pipes[i], F_GETFL, 0);
-		fcntl(pipes[i], F_SETFL, flags | O_NONBLOCK);
-	}
-
-	return 0;
-}
-
-static int tty_callback(int *ssh_fds)
-{
-	static bool special;
-	struct msg hdr;
-	char buf[32];
-	ssize_t k;
-	ssize_t n;
-
-	n = read(STDIN_FILENO, buf, sizeof(buf));
-	if (n < 0)
-		return n;
-
-	for (k = 0; k < n; k++) {
-		if (buf[k] == 0x1) {
-			special = true;
-		} else if (special) {
-			switch (buf[k]) {
-			case 'q':
-				quit = true;
-				break;
-			case 'P':
-				hdr.type = MSG_POWER_ON;
-				hdr.len = 0;
-				write(ssh_fds[0], &hdr, sizeof(hdr));
-				break;
-			case 'p':
-				hdr.type = MSG_POWER_OFF;
-				hdr.len = 0;
-				write(ssh_fds[0], &hdr, sizeof(hdr));
-				break;
-			case 's':
-				hdr.type = MSG_STATUS_UPDATE;
-				hdr.len = 0;
-				write(ssh_fds[0], &hdr, sizeof(hdr));
-				break;
-			case 'V':
-				hdr.type = MSG_VBUS_ON;
-				hdr.len = 0;
-				write(ssh_fds[0], &hdr, sizeof(hdr));
-				break;
-			case 'v':
-				hdr.type = MSG_VBUS_OFF;
-				hdr.len = 0;
-				write(ssh_fds[0], &hdr, sizeof(hdr));
-				break;
-			case 'a':
-				hdr.type = MSG_CONSOLE;
-				hdr.len = 1;
-
-				write(ssh_fds[0], &hdr, sizeof(hdr));
-				write(ssh_fds[0], "\001", 1);
-				break;
-			case 'B':
-				hdr.type = MSG_SEND_BREAK;
-				hdr.len = 0;
-				write(ssh_fds[0], &hdr, sizeof(hdr));
-				break;
-			}
-
-			special = false;
-		} else {
-			hdr.type = MSG_CONSOLE;
-			hdr.len = 1;
-
-			write(ssh_fds[0], &hdr, sizeof(hdr));
-			write(ssh_fds[0], buf + k, 1);
-		}
-	}
-
-	return 0;
-}
-
-struct work {
-	void (*fn)(struct work *work, int ssh_stdin);
-
-	struct list_head node;
-};
-
-static struct list_head work_items = LIST_INIT(work_items);
-
-static void list_boards_fn(struct work *work, int ssh_stdin)
-{
-	struct msg msg;
-	ssize_t n;
-
-	msg.type = MSG_LIST_DEVICES;
-	msg.len = 0;
-
-	n = write(ssh_stdin, &msg, sizeof(msg));
-	if (n < 0)
-		err(1, "failed to send board list request");
-
-	free(work);
-}
-
-static void request_board_list(void)
-{
-	struct work *work;
-
-	work = malloc(sizeof(*work));
-	work->fn = list_boards_fn;
-
-	list_add(&work_items, &work->node);
-}
-
-struct board_info_request {
-	struct work work;
-	const char *board;
-};
-
-static void board_info_fn(struct work *work, int ssh_stdin)
-{
-	struct board_info_request *board = container_of(work, struct board_info_request, work);
-	size_t blen = strlen(board->board) + 1;
-	struct msg *msg;
-	ssize_t n;
-
-	msg = alloca(sizeof(*msg) + blen);
-	msg->type = MSG_BOARD_INFO;
-	msg->len = blen;
-	memcpy(msg->data, board->board, blen);
-
-	n = write(ssh_stdin, msg, sizeof(*msg) + blen);
-	if (n < 0)
-		err(1, "failed to send board info request");
-
-	free(work);
-}
-
-static void request_board_info(const char *board)
-{
-	struct board_info_request *work;
-
-	work = malloc(sizeof(*work));
-	work->work.fn = board_info_fn;
-	work->board = board;
-
-	list_add(&work_items, &work->work.node);
-}
-
-struct select_board {
-	struct work work;
-
-	const char *board;
-};
-
-static void select_board_fn(struct work *work, int ssh_stdin)
-{
-	struct select_board *board = container_of(work, struct select_board, work);
-	size_t blen = strlen(board->board) + 1;
-	struct msg *msg;
-	ssize_t n;
-
-	msg = alloca(sizeof(*msg) + blen);
-	msg->type = MSG_SELECT_BOARD;
-	msg->len = blen;
-	memcpy(msg->data, board->board, blen);
-
-	n = write(ssh_stdin, msg, sizeof(*msg) + blen);
-	if (n < 0)
-		err(1, "failed to send power on request");
-
-	free(work);
-}
-
-static void request_select_board(const char *board)
-{
-	struct select_board *work;
-
-	work = malloc(sizeof(*work));
-	work->work.fn = select_board_fn;
-	work->board = board;
-
-	list_add(&work_items, &work->work.node);
-}
-
-static void request_power_on_fn(struct work *work, int ssh_stdin)
-{
-	struct msg msg = { MSG_POWER_ON, };
-	ssize_t n;
-
-	n = write(ssh_stdin, &msg, sizeof(msg));
-	if (n < 0)
-		err(1, "failed to send power on request");
-}
-
-static void request_power_off_fn(struct work *work, int ssh_stdin)
-{
-	struct msg msg = { MSG_POWER_OFF, };
-	ssize_t n;
-
-	n = write(ssh_stdin, &msg, sizeof(msg));
-	if (n < 0)
-		err(1, "failed to send power off request");
-}
-
-static void request_power_on(void)
-{
-	static struct work work = { request_power_on_fn };
-
-	list_add(&work_items, &work.node);
-}
-
-static void request_power_off(void)
-{
-	static struct work work = { request_power_off_fn };
-
-	list_add(&work_items, &work.node);
-}
 
 struct fastboot_download_work {
 	struct work work;
@@ -416,400 +115,103 @@ static void request_fastboot_files(void)
 	list_add(&work_items, &work->work.node);
 }
 
-static void handle_status_update(const void *data, size_t len)
+void cdba_usage(const char *__progname)
 {
-	char *str = alloca(len + 1);
-
-	memcpy(str, data, len);
-	str[len] = '\n';
-
-	write(STDOUT_FILENO, str, len + 1);
-}
-
-static void handle_list_devices(const void *data, size_t len)
-{
-	char *board;
-
-	if (!len) {
-		quit = true;
-		return;
-	}
-
-	board = alloca(len + 1);
-	memcpy(board, data, len);
-	board[len] = '\n';
-	write(STDOUT_FILENO, board, len + 1);
-}
-
-static void handle_board_info(const void *data, size_t len)
-{
-	char *info;
-
-	info = alloca(len + 1);
-	memcpy(info, data, len);
-	info[len] = '\n';
-	write(STDOUT_FILENO, info, len + 1);
-
-	quit = true;
-}
-
-static bool received_power_off;
-static bool reached_timeout;
-
-static void handle_console(const void *data, size_t len)
-{
-	static int power_off_chars = 0;
-	const char *p = data;
-	int i;
-
-	for (i = 0; i < len; i++) {
-		if (*p++ == '~') {
-			if (power_off_chars++ == 19) {
-				received_power_off = true;
-				power_off_chars = 0;
-			}
-		} else {
-			power_off_chars = 0;
-		}
-	}
-
-	write(STDOUT_FILENO, data, len);
-}
-
-static bool auto_power_on;
-
-static int handle_message(struct circ_buf *buf)
-{
-	struct msg *msg;
-	struct msg hdr;
-	size_t n;
-
-	for (;;) {
-		n = circ_peak(buf, &hdr, sizeof(hdr));
-		if (n != sizeof(hdr))
-			return 0;
-
-		if (CIRC_AVAIL(buf) < sizeof(*msg) + hdr.len)
-			return 0;
-
-		// fprintf(stderr, "avail: %zd hdr.len: %d\n", CIRC_AVAIL(buf), hdr.len);
-
-		msg = malloc(sizeof(*msg) + hdr.len);
-		circ_read(buf, msg, sizeof(*msg) + hdr.len);
-
-		switch (msg->type) {
-		case MSG_SELECT_BOARD:
-			// printf("======================================== MSG_SELECT_BOARD\n");
-			request_power_on();
-			break;
-		case MSG_CONSOLE:
-			handle_console(msg->data, msg->len);
-			break;
-		case MSG_HARDRESET:
-			break;
-		case MSG_POWER_ON:
-			// printf("======================================== MSG_POWER_ON\n");
-			break;
-		case MSG_POWER_OFF:
-			// printf("======================================== MSG_POWER_OFF\n");
-			if (auto_power_on) {
-				sleep(2);
-				request_power_on();
-			}
-			break;
-		case MSG_FASTBOOT_PRESENT:
-			if (*(uint8_t*)msg->data) {
-				// printf("======================================== MSG_FASTBOOT_PRESENT(on)\n");
-				if (!fastboot_done || fastboot_repeat)
-					request_fastboot_files();
-				else
-					quit = true;
-			} else {
-				fastboot_done = true;
-				// printf("======================================== MSG_FASTBOOT_PRESENT(off)\n");
-			}
-			break;
-		case MSG_FASTBOOT_DOWNLOAD:
-			// printf("======================================== MSG_FASTBOOT_DOWNLOAD\n");
-			break;
-		case MSG_FASTBOOT_BOOT:
-			// printf("======================================== MSG_FASTBOOT_BOOT\n");
-			break;
-		case MSG_STATUS_UPDATE:
-			handle_status_update(msg->data, msg->len);
-			break;
-		case MSG_LIST_DEVICES:
-			handle_list_devices(msg->data, msg->len);
-			break;
-		case MSG_BOARD_INFO:
-			handle_board_info(msg->data, msg->len);
-			return -1;
-			break;
-		default:
-			fprintf(stderr, "unk %d len %d\n", msg->type, msg->len);
-			return -1;
-		}
-
-		free(msg);
-	}
-
-	return 0;
-}
-
-static struct timeval get_timeout(int sec)
-{
-	struct timeval delta = { .tv_sec = sec };
-	struct timeval now;
-	struct timeval tv;
-
-	gettimeofday(&now, NULL);
-	timeradd(&now, &delta, &tv);
-
-	return tv;
-}
-
-static void usage(void)
-{
-	extern const char *__progname;
-
 	fprintf(stderr, "usage: %s -b <board> -h <host> [-t <timeout>] "
 			"[-T <inactivity-timeout>] boot.img\n",
 			__progname);
-	fprintf(stderr, "usage: %s -i -b <board> -h <host>\n",
-			__progname);
-	fprintf(stderr, "usage: %s -l -h <host>\n",
-			__progname);
-	exit(1);
 }
 
-enum {
-	CDBA_BOOT,
-	CDBA_LIST,
-	CDBA_INFO,
-};
-
-int main(int argc, char **argv)
+int cdba_handle_opt(int opt, const char *optarg)
 {
-	bool power_cycle_on_timeout = true;
-	struct timeval timeout_inactivity_tv;
-	struct timeval timeout_total_tv;
-	struct termios *orig_tios;
-	const char *server_binary = "cdba-server";
-	int timeout_inactivity = 0;
-	int timeout_total = 600;
-	struct work *next;
-	struct work *work;
-	struct circ_buf recv_buf = { 0 };
-	const char *board = NULL;
-	const char *host = NULL;
-	struct timeval now;
-	struct timeval tv;
-	int power_cycles = 0;
-	struct stat sb;
-	int ssh_fds[3];
-	char buf[128];
-	fd_set rfds;
-	fd_set wfds;
-	ssize_t n;
-	int nfds;
-	int verb = CDBA_BOOT;
-	int opt;
-	int ret;
-
-	while ((opt = getopt(argc, argv, "b:c:C:h:ilRt:S:T:")) != -1) {
-		switch (opt) {
-		case 'b':
-			board = optarg;
-			break;
-		case 'C':
-			power_cycle_on_timeout = false;
-			/* FALLTHROUGH */
-		case 'c':
-			power_cycles = atoi(optarg);
-			break;
-		case 'h':
-			host = optarg;
-			break;
-		case 'i':
-			verb = CDBA_INFO;
-			break;
-		case 'l':
-			verb = CDBA_LIST;
-			break;
-		case 'R':
-			fastboot_repeat = true;
-			break;
-		case 'S':
-			server_binary = optarg;
-			break;
-		case 't':
-			timeout_total = atoi(optarg);
-			break;
-		case 'T':
-			timeout_inactivity = atoi(optarg);
-			break;
-		default:
-			usage();
-		}
+	switch (opt) {
+	case 'R':
+		fastboot_repeat = true;
+		return 0;
 	}
 
-	if (!host)
-		usage();
+	return 1;
+}
+
+void cdba_handle_verb(int argc, char **argv, int optind, const char *board)
+{
+	struct stat sb;
 
 	switch (verb) {
 	case CDBA_BOOT:
 		if (optind >= argc || !board)
-			usage();
+			cdba_client_usage();
 
-		fastboot_file = argv[optind];
+		fastboot_file = argv[argc - 1];
 		if (lstat(fastboot_file, &sb))
 			err(1, "unable to read \"%s\"", fastboot_file);
 		if (!S_ISREG(sb.st_mode) && !S_ISLNK(sb.st_mode))
 			errx(1, "\"%s\" is not a regular file", fastboot_file);
 
-		request_select_board(board);
-		break;
-	case CDBA_LIST:
-		request_board_list();
-		break;
-	case CDBA_INFO:
-		if (!board)
-			usage();
-
-		request_board_info(board);
+		cdba_client_request_select_board(board);
 		break;
 	}
+}
 
-	ret = fork_ssh(host, server_binary, ssh_fds);
-	if (ret)
-		err(1, "failed to connect to \"%s\"", host);
+int cdba_handle_message(struct msg *msg)
+{
+	int rc = 0;
 
-	orig_tios = tty_unbuffer();
-
-	timeout_total_tv = get_timeout(timeout_total);
-	timeout_inactivity_tv = get_timeout(timeout_inactivity);
-
-	while (!quit) {
-		if (received_power_off || reached_timeout) {
-			if (!power_cycles)
-				break;
-
-			if (reached_timeout && !power_cycle_on_timeout)
-				break;
-
-			printf("power cycle (%d left)\n", power_cycles);
-			fflush(stdout);
-
-			auto_power_on = true;
-			power_cycles--;
-			received_power_off = false;
-			reached_timeout = false;
-
-			request_power_off();
-
-			timeout_inactivity_tv = get_timeout(timeout_inactivity);
+	switch (msg->type) {
+	case MSG_SELECT_BOARD:
+		// printf("======================================== MSG_SELECT_BOARD\n");
+		cdba_client_request_power_on();
+		break;
+	case MSG_HARDRESET:
+		break;
+	case MSG_POWER_ON:
+		// printf("======================================== MSG_POWER_ON\n");
+		break;
+	case MSG_POWER_OFF:
+		// printf("======================================== MSG_POWER_OFF\n");
+		if (auto_power_on) {
+			sleep(2);
+			cdba_client_request_power_on();
 		}
-
-		FD_ZERO(&rfds);
-		FD_SET(ssh_fds[1], &rfds);
-		FD_SET(ssh_fds[2], &rfds);
-		nfds = MAX(ssh_fds[1], ssh_fds[2]);
-
-		if (orig_tios) {
-			FD_SET(STDIN_FILENO, &rfds);
-
-			nfds = MAX(nfds, STDIN_FILENO);
-		}
-
-		FD_ZERO(&wfds);
-		if (!list_empty(&work_items))
-			FD_SET(ssh_fds[0], &wfds);
-
-		gettimeofday(&now, NULL);
-		if (timeout_inactivity && timercmp(&timeout_inactivity_tv, &timeout_total_tv, <)) {
-			timersub(&timeout_inactivity_tv, &now, &tv);
-		} else {
-			timersub(&timeout_total_tv, &now, &tv);
-		}
-
-		ret = select(nfds + 1, &rfds, &wfds, NULL, &tv);
-#if 0
-		printf("select: %d (%c%c%c)\n", ret, FD_ISSET(STDIN_FILENO, &rfds) ? 'X' : '-',
-						     FD_ISSET(ssh_fds[1], &rfds) ? 'X' : '-',
-						     FD_ISSET(ssh_fds[2], &rfds) ? 'X' : '-');
-#endif
-		if (ret < 0) {
-			err(1, "select");
-		} else if (ret == 0) {
-			if (timeout_inactivity && timercmp(&timeout_inactivity_tv, &timeout_total_tv, <))
-				warnx("timeout due to inactivity");
+		break;
+	case MSG_FASTBOOT_PRESENT:
+		if (*(uint8_t*)msg->data) {
+			// printf("======================================== MSG_FASTBOOT_PRESENT(on)\n");
+			if (!fastboot_done || fastboot_repeat)
+				request_fastboot_files();
 			else
-				warnx("timeout reached");
-
-			reached_timeout = true;
+				cdba_client_quit = true;
+		} else {
+			fastboot_done = true;
+			// printf("======================================== MSG_FASTBOOT_PRESENT(off)\n");
 		}
-
-		if (FD_ISSET(STDIN_FILENO, &rfds))
-			tty_callback(ssh_fds);
-
-		if (FD_ISSET(ssh_fds[2], &rfds)) {
-			n = read(ssh_fds[2], buf, sizeof(buf));
-			if (!n) {
-				warnx("EOF on stderr");
-				break;
-			} else if (n < 0 && errno == EAGAIN) {
-			       continue;
-			} else if (n < 0) {
-				warn("received %zd on stderr", n);
-				break;
-			}
-
-			const char blue[] = "\033[94m";
-			const char reset[] = "\033[0m";
-
-			write(2, blue, sizeof(blue) - 1);
-			write(2, buf, n);
-			write(2, reset, sizeof(reset) - 1);
-		}
-
-		if (FD_ISSET(ssh_fds[1], &rfds)) {
-			ret = circ_fill(ssh_fds[1], &recv_buf);
-			if (ret < 0 && errno != EAGAIN) {
-				warn("received %d on stdout", ret);
-				break;
-			}
-
-			n = handle_message(&recv_buf);
-			if (n < 0)
-				break;
-
-			/* Reset inactivity timeout on activity */
-			if (timeout_inactivity)
-				timeout_inactivity_tv = get_timeout(timeout_inactivity);
-		}
-
-		if (FD_ISSET(ssh_fds[0], &wfds)) {
-			list_for_each_entry_safe(work, next, &work_items, node) {
-				list_del(&work->node);
-
-				work->fn(work, ssh_fds[0]);
-			}
-		}
+		break;
+	case MSG_FASTBOOT_DOWNLOAD:
+		// printf("======================================== MSG_FASTBOOT_DOWNLOAD\n");
+		break;
+	case MSG_FASTBOOT_BOOT:
+		// printf("======================================== MSG_FASTBOOT_BOOT\n");
+		break;
+	default:
+		rc = -1;
+		break;
 	}
 
-	close(ssh_fds[0]);
-	close(ssh_fds[1]);
-	close(ssh_fds[2]);
+	return rc;
+}
 
+void cdba_end(void)
+{
 	if (verb == CDBA_BOOT)
 		printf("Waiting for ssh to finish\n");
+}
 
-	wait(NULL);
+int cdba_client_reached_timeout(void)
+{
+	return fastboot_done ? 110 : 2;
+}
 
-	tty_reset(orig_tios);
-
-	if (reached_timeout)
-		return fastboot_done ? 110 : 2;
-
-	return (quit || received_power_off) ? 0 : 1;
+int main(int argc, char **argv)
+{
+	cdba_client_main(argc, argv, cdba_opts);
 }

--- a/cdba.c
+++ b/cdba.c
@@ -148,7 +148,7 @@ void cdba_handle_verb(int argc, char **argv, int optind, const char *board)
 		if (!S_ISREG(sb.st_mode) && !S_ISLNK(sb.st_mode))
 			errx(1, "\"%s\" is not a regular file", fastboot_file);
 
-		cdba_client_request_select_board(board);
+		cdba_client_request_select_board(board, 1);
 		break;
 	}
 }

--- a/cdba.c
+++ b/cdba.c
@@ -148,7 +148,7 @@ void cdba_handle_verb(int argc, char **argv, int optind, const char *board)
 		if (!S_ISREG(sb.st_mode) && !S_ISLNK(sb.st_mode))
 			errx(1, "\"%s\" is not a regular file", fastboot_file);
 
-		cdba_client_request_select_board(board, 1);
+		cdba_client_request_select_board(board, 0, 1);
 		break;
 	}
 }

--- a/cdba.h
+++ b/cdba.h
@@ -1,35 +1,10 @@
 #ifndef __CDBA_H__
 #define __CDBA_H__
 
-#include <stdint.h>
+#include "cdba-client.h"
 
-#define __packed __attribute__((packed))
-
-#define MIN(x, y) ((x) < (y) ? (x) : (y))
-#define MAX(x, y) ((x) > (y) ? (x) : (y))
-
-struct msg {
-	uint8_t type;
-	uint16_t len;
-	uint8_t data[];
-} __packed;
-
-enum {
-	MSG_SELECT_BOARD = 1,
-	MSG_CONSOLE,
-	MSG_HARDRESET,
-	MSG_POWER_ON,
-	MSG_POWER_OFF,
-	MSG_FASTBOOT_PRESENT,
-	MSG_FASTBOOT_DOWNLOAD,
-	MSG_FASTBOOT_BOOT,
-	MSG_STATUS_UPDATE,
-	MSG_VBUS_ON,
-	MSG_VBUS_OFF,
-	MSG_FASTBOOT_REBOOT,
-	MSG_SEND_BREAK,
-	MSG_LIST_DEVICES,
-	MSG_BOARD_INFO,
+enum cdba_verbs {
+	CDBA_BOOT = MAX_CDBA_CLIENT_VERBS,
 };
 
-#endif
+#endif // __CDBA_H__

--- a/device.c
+++ b/device.c
@@ -74,7 +74,10 @@ static void device_lock(struct device *device)
 	if (!n)
 		return;
 
-	warnx("board is in use, waiting...");
+	if (device->standalone)
+		err(1, "board is in use, exiting...");
+	else
+		warnx("board is in use, waiting...");
 
 	n = flock(fd, LOCK_EX);
 	if (n < 0)

--- a/device.c
+++ b/device.c
@@ -114,7 +114,7 @@ found:
 			errx(1, "failed to open device controller");
 	}
 
-	if (cdba_server_standalone_create(device) == -1)
+	if (device->standalone && cdba_server_standalone_create(device) == -1)
 		errx(1, "failed to open standalone server");
 
 	if (device->console_dev)
@@ -332,7 +332,8 @@ void device_close(struct device *dev)
 		device_usb(dev, false);
 	device_power(dev, false);
 
-	cdba_server_standalone_end(dev);
+	if (dev->standalone)
+		cdba_server_standalone_end(dev);
 
 	if (dev->close)
 		dev->close(dev);

--- a/device.c
+++ b/device.c
@@ -38,8 +38,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "cdba-server.h"
+#include "cdba-server-standalone.h"
 #include "device.h"
 #include "fastboot.h"
 #include "console.h"
@@ -106,6 +108,9 @@ found:
 		if (!device->cdb)
 			errx(1, "failed to open device controller");
 	}
+
+	if (cdba_server_standalone_create(device) == -1)
+		errx(1, "failed to open standalone server");
 
 	if (device->console_dev)
 		console_open(device);
@@ -320,6 +325,8 @@ void device_close(struct device *dev)
 	if (!dev->usb_always_on)
 		device_usb(dev, false);
 	device_power(dev, false);
+
+	cdba_server_standalone_end(dev);
 
 	if (dev->close)
 		dev->close(dev);

--- a/device.h
+++ b/device.h
@@ -22,6 +22,7 @@ struct device {
 	unsigned int fastboot_key_timeout;
 	int state;
 	bool has_power_key;
+	int locked;
 
 	void (*boot)(struct device *);
 
@@ -47,7 +48,7 @@ struct device {
 
 void device_add(struct device *device);
 
-struct device *device_open(const char *board, struct fastboot_ops *fastboot_ops);
+struct device *device_open(const void *msg, struct fastboot_ops *fastboot_ops);
 void device_close(struct device *dev);
 int device_power(struct device *device, bool on);
 

--- a/device.h
+++ b/device.h
@@ -43,6 +43,8 @@ struct device {
 	int console_fd;
 	struct termios console_tios;
 
+	int standalone_channel;
+
 	struct list_head node;
 };
 

--- a/device.h
+++ b/device.h
@@ -22,6 +22,7 @@ struct device {
 	unsigned int fastboot_key_timeout;
 	int state;
 	bool has_power_key;
+	int standalone;
 	int locked;
 
 	void (*boot)(struct device *);


### PR DESCRIPTION
This new cdba standalone support include actions for get console and power on/off the device useful in LAVA jobs.