### PR TITLE
ci: add basic Github Actions Continuous Integration builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2021 Canonical Ltd.
+# Copyright (c) 2023 Linaro Ltd
+# Author: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+#                             <krzk@kernel.org>
+#
+# Loosely based on: https://github.com/linux-test-project/ltp
+#                   https://github.com/linux-nfc/neard
+#
+name: "Builds"
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  job:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86-64]
+        compiler: [gcc, clang]
+        container:
+          - archlinux:latest
+          - debian:testing
+          - debian:stable
+          - debian:bookworm
+          - debian:bullseye
+          - debian:buster
+          # Fails on configure on GCC and clang (process restrictions?)
+          # - fedora:rawhide
+          - fedora:latest
+          - fedora:39
+          - fedora:38
+          - fedora:37
+          - fedora:36
+          - fedora:35
+          - fedora:34
+          - ubuntu:lunar
+          - ubuntu:kinetic
+          - ubuntu:jammy
+          - ubuntu:focal
+          - ubuntu:bionic
+          - ubuntu:xenial
+        cross_compile: [""]
+        variant: [""]
+        include:
+          # Debian 32-bit builds
+          - container: "debian:testing"
+            arch: i386
+            compiler: gcc -m32
+            cross_compile: i686-linux-gnu
+            variant: i386
+
+          - container: "debian:stable"
+            arch: i386
+            compiler: gcc -m32
+            cross_compile: i686-linux-gnu
+            variant: i386
+
+          - container: "debian:bookworm"
+            arch: i386
+            compiler: gcc -m32
+            cross_compile: i686-linux-gnu
+            variant: i386
+
+          - container: "debian:buster"
+            arch: i386
+            compiler: gcc -m32
+            cross_compile: i686-linux-gnu
+            variant: i386
+
+          # Debian cross compilation builds
+          - container: "debian:testing"
+            arch: armel
+            compiler: arm-linux-gnueabi-gcc
+            cross_compile: arm-linux-gnueabi
+            variant: cross-compile
+
+          - container: "debian:testing"
+            arch: arm64
+            compiler: aarch64-linux-gnu-gcc
+            cross_compile: aarch64-linux-gnu
+            variant: cross-compile
+
+          - container: "debian:testing"
+            arch: ppc64el
+            compiler: powerpc64le-linux-gnu-gcc
+            cross_compile: powerpc64le-linux-gnu
+            variant: cross-compile
+
+          - container: "debian:testing"
+            arch: s390x
+            compiler: s390x-linux-gnu-gcc
+            cross_compile: s390x-linux-gnu
+            variant: cross-compile
+
+          - container: "debian:stable"
+            arch: armel
+            compiler: arm-linux-gnueabi-gcc
+            cross_compile: arm-linux-gnueabi
+            variant: cross-compile
+
+          - container: "debian:stable"
+            arch: arm64
+            compiler: aarch64-linux-gnu-gcc
+            cross_compile: aarch64-linux-gnu
+            variant: cross-compile
+
+          - container: "debian:stable"
+            arch: ppc64el
+            compiler: powerpc64le-linux-gnu-gcc
+            cross_compile: powerpc64le-linux-gnu
+            variant: cross-compile
+
+          - container: "debian:stable"
+            arch: s390x
+            compiler: s390x-linux-gnu-gcc
+            cross_compile: s390x-linux-gnu
+            variant: cross-compile
+
+    container:
+      image: ${{ matrix.container }}
+      env:
+        ARCH: ${{ matrix.arch }}
+        CC: ${{ matrix.compiler }}
+        CROSS_COMPILE: ${{ matrix.cross_compile }}
+        MODE: ${{ matrix.mode }}
+        VARIANT: ${{ matrix.variant }}
+
+    steps:
+    - name: Show OS
+      run: cat /etc/os-release
+
+    - name: Show env (matrix settings)
+      run: |
+        echo "ARCH: $ARCH"
+        echo "CC: $CC"
+        echo "CROSS_COMPILE: $CROSS_COMPILE"
+        echo "MODE: $MODE"
+        echo "VARIANT: $VARIANT"
+
+    - name: Git checkout
+      uses: actions/checkout@v3
+
+    - name: Install additional packages
+      run: |
+        INSTALL=${{ matrix.container }}
+        INSTALL="${INSTALL%%:*}"
+        INSTALL="${INSTALL%%/*}"
+        ./ci/$INSTALL.sh
+        if [ "$VARIANT" ]; then ./ci/$INSTALL.$VARIANT.sh; fi
+
+    - name: Compiler version
+      run: $CC --version
+
+    - name: Display environment and Linux version
+      run: |
+        test -f /etc/issue && cat /etc/issue
+        echo "############################################"
+        lsb_release -a || true
+        echo "############################################"
+        cat /usr/include/linux/version.h
+        echo "############################################"
+        uname -a
+        echo "############################################"
+        cat /proc/cmdline
+        echo "############################################"
+        printenv
+
+    - name: Compile
+      run: make -j$(nproc)
+
+    - name: Install
+      run: make install

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2021 Canonical Ltd.
+# Copyright (c) 2023 Linaro Ltd
+# Author: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+#                             <krzk@kernel.org>
+#
+name: "CodeQL"
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Install additional packages
+      run: sudo ./ci/ubuntu.sh
+
+    - name: Compile
+      run: |
+        make -j$(nproc)
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/ci/archlinux.sh
+++ b/ci/archlinux.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2021 Canonical Ltd.
+# Copyright (c) 2023 Linaro Ltd
+# Author: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+#                             <krzk@kernel.org>
+#
+
+set -ex
+
+PKGS_CC="gcc"
+case $CC in
+	clang*)
+		PKGS_CC="clang"
+	;;
+esac
+
+pacman -Sy --noconfirm \
+	libftdi-compat \
+	libyaml \
+	systemd-libs \
+	make \
+	$PKGS_CC
+
+echo "Install finished: $0"

--- a/ci/debian.cross-compile.sh
+++ b/ci/debian.cross-compile.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2018-2020 Petr Vorel <pvorel@suse.cz>
+# Copyright (c) 2021 Canonical Ltd.
+# Copyright (c) 2023 Linaro Ltd
+# Author: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+#                             <krzk@kernel.org>
+#
+
+set -ex
+
+if [ -z "$ARCH" ]; then
+	echo "missing \$ARCH!" >&2
+	exit 1
+fi
+
+case "$ARCH" in
+	armel) PKGS_CC="gcc-arm-linux-gnueabi libc6-dev-${ARCH}-cross";;
+	arm64) PKGS_CC="gcc-aarch64-linux-gnu libc6-dev-${ARCH}-cross";;
+	ppc64el) PKGS_CC="gcc-powerpc64le-linux-gnu libc6-dev-${ARCH}-cross";;
+	# TODO: libraries for riscv?
+	#riscv64) PKGS_CC="gcc-riscv64-linux-gnu libc6-dev-${ARCH}-cross";;
+	s390x) PKGS_CC="gcc-${ARCH}-linux-gnu libc6-dev-${ARCH}-cross";;
+	*) echo "unsupported arch: '$ARCH'!" >&2; exit 1;;
+esac
+
+dpkg --add-architecture $ARCH
+apt update
+
+apt install -y --no-install-recommends \
+	libftdi-dev:${ARCH} \
+	libudev-dev:${ARCH} \
+	libyaml-dev:${ARCH} \
+	$PKGS_CC
+
+echo "Install finished: $0"

--- a/ci/debian.i386.sh
+++ b/ci/debian.i386.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2018-2020 Petr Vorel <pvorel@suse.cz>
+# Copyright (c) 2021 Canonical Ltd.
+# Copyright (c) 2023 Linaro Ltd
+# Author: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+#                             <krzk@kernel.org>
+#
+
+set -ex
+
+dpkg --add-architecture i386
+apt update
+
+# gcc-multilib are also needed for clang 32-bit builds
+PKGS_CC="gcc-multilib"
+
+apt install -y --no-install-recommends \
+	linux-libc-dev:i386
+
+apt install -y --no-install-recommends \
+	libftdi-dev:i386 \
+	libudev-dev:i386 \
+	libyaml-dev:i386 \
+	$PKGS_CC
+
+echo "Install finished: $0"

--- a/ci/debian.sh
+++ b/ci/debian.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2021 Canonical Ltd.
+# Copyright (c) 2023 Linaro Ltd
+# Author: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+#                             <krzk@kernel.org>
+#
+
+set -ex
+
+apt update
+
+# Some distros (e.g. Ubuntu Hirsute) might pull tzdata which asks questions
+export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
+
+# Choose some random place in Europe
+echo "tzdata tzdata/Areas select Europe
+tzdata tzdata/Zones/Europe select Berlin
+" > /tmp/tzdata-preseed.txt
+debconf-set-selections /tmp/tzdata-preseed.txt
+
+PKGS_CC="build-essential"
+case $CC in
+	clang*)
+		PKGS_CC="clang"
+	;;
+esac
+
+apt install -y --no-install-recommends \
+	libftdi-dev \
+	libudev-dev \
+	libyaml-dev \
+	make \
+	$PKGS_CC
+
+echo "Install finished: $0"

--- a/ci/fedora.sh
+++ b/ci/fedora.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2021 Canonical Ltd.
+# Copyright (c) 2023 Linaro Ltd
+# Author: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+#                             <krzk@kernel.org>
+#
+
+set -ex
+
+PKGS_CC="gcc"
+case $CC in
+	clang*)
+		PKGS_CC="clang"
+	;;
+esac
+
+dnf -y install \
+	libftdi-devel \
+	libudev-devel \
+	libyaml-devel \
+	make \
+	$PKGS_CC
+
+echo "Install finished: $0"

--- a/ci/ubuntu.cross-compile.sh
+++ b/ci/ubuntu.cross-compile.sh
@@ -1,0 +1,1 @@
+debian.cross-compile.sh

--- a/ci/ubuntu.i386.sh
+++ b/ci/ubuntu.i386.sh
@@ -1,0 +1,1 @@
+debian.i386.sh

--- a/ci/ubuntu.sanitizers.sh
+++ b/ci/ubuntu.sanitizers.sh
@@ -1,0 +1,1 @@
+debian.sanitizers.sh

--- a/ci/ubuntu.sh
+++ b/ci/ubuntu.sh
@@ -1,0 +1,1 @@
+debian.sh


### PR DESCRIPTION
Add Continuous Integration using Github actions, re-using similar setup from linux-nfc/neard [1] (dropped Alpine, Ubuntu i386, sanitizers and few others action steps).  Since I copied most files, I retained all original copyrights.

The CI will build cdba for several different distros and architectures.

The Fedora builds will fail, because it does not have libftdi-compat (or libftdi1) package.

[1] https://github.com/linux-nfc/neard