### PR TITLE
Fix some GCC and clang warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,26 @@ SERVER := cdba-server
 all: $(CLIENT) $(SERVER)
 
 CFLAGS := -Wall -g -O2
+# Wextra without few warnings
+CFLAGS := $(CFLAGS) -Wextra -Wno-unused-parameter -Wno-unused-result -Wno-missing-field-initializers -Wno-sign-compare
+
+# Few clang version still have warnings so fail only on GCC
+GCC_CFLAGS := -Werror
+GCC_CFLAGS += -Wformat-signedness -Wnull-dereference -Wduplicated-cond -Wduplicated-branches -Wvla-larger-than=1
+GCC_CFLAGS += -Walloc-zero -Wstringop-truncation -Wdouble-promotion -Wshadow -Wunsafe-loop-optimizations
+GCC_CFLAGS += -Wpointer-arith -Wcast-align -Wwrite-strings -Wlogical-op -Wstrict-overflow=4 -Wundef -Wjump-misses-init
+CLANG_CFLAGS := -Wnull-dereference -Wdouble-promotion -Wshadow -Wpointer-arith -Wwrite-strings -Wstrict-overflow=4 -Wundef
+# TODO:
+# GCC_CFLAGS += -Wcast-qual
+# CLANG_CFLAGS += -Wcast-qual -Wcast-align
+ifeq ($(CC),cc)
+  CFLAGS += $(GCC_CFLAGS)
+else ifeq ($(CC),clang)
+  CFLAGS += $(CLANG_CFLAGS)
+else
+  $(info No compiler flags for: $(CC))
+endif
+
 LDFLAGS := -ludev -lyaml -lftdi -lusb
 
 CLIENT_SRCS := cdba.c circ_buf.c

--- a/cdb_assist.c
+++ b/cdb_assist.c
@@ -348,7 +348,7 @@ void cdb_assist_print_status(struct device *dev)
 	char buf[128];
 	int n;
 
-	n = sprintf(buf, "%dmV %dmA%s%s%s%s%s ref: %dmV",
+	n = sprintf(buf, "%umV %umA%s%s%s%s%s ref: %umV",
 			 cdb->voltage_set,
 			 cdb->current_actual,
 			 cdb->vbat ? " vbat" : "",
@@ -369,7 +369,7 @@ void cdb_set_voltage(struct cdb_assist *cdb, unsigned mV)
 	char buf[20];
 	int n;
 
-	n = sprintf(buf, "u%d\r\n", mV);
+	n = sprintf(buf, "u%u\r\n", mV);
 	cdb_ctrl_write(cdb, buf, n);
 }
 

--- a/cdba-server.c
+++ b/cdba-server.c
@@ -137,7 +137,7 @@ static void msg_fastboot_download(const void *data, size_t len)
 {
 	struct msg reply = { MSG_FASTBOOT_DOWNLOAD, };
 	size_t new_size = fastboot_size + len;
-	void *newp;
+	char *newp;
 
 	newp = realloc(fastboot_payload, new_size);
 	if (!newp)

--- a/cdba-server.c
+++ b/cdba-server.c
@@ -95,7 +95,7 @@ static void fastboot_opened(struct fastboot *fb, void *data)
 
 static void fastboot_info(struct fastboot *fb, const void *buf, size_t len)
 {
-	fprintf(stderr, "%s\n", (char *)buf);
+	fprintf(stderr, "%s\n", (const char *)buf);
 }
 
 static void fastboot_disconnect(void *data)

--- a/cdba.c
+++ b/cdba.c
@@ -374,7 +374,7 @@ static void fastboot_work_fn(struct work *_work, int ssh_stdin)
 	msg = alloca(sizeof(*msg) + left);
 	msg->type = MSG_FASTBOOT_DOWNLOAD;
 	msg->len = left;
-	memcpy(msg->data, work->data + work->offset, left);
+	memcpy(msg->data, (char *)work->data + work->offset, left);
 
 	n = write(ssh_stdin, msg, sizeof(*msg) + msg->len);
 	if (n < 0 && errno == EAGAIN) {

--- a/circ_buf.c
+++ b/circ_buf.c
@@ -45,7 +45,7 @@
  */
 ssize_t circ_fill(int fd, struct circ_buf *circ)
 {
-	size_t space;
+	ssize_t space;
 	size_t count = 0;
 	ssize_t n = 0;
 

--- a/circ_buf.c
+++ b/circ_buf.c
@@ -46,7 +46,6 @@
 ssize_t circ_fill(int fd, struct circ_buf *circ)
 {
 	ssize_t space;
-	size_t count = 0;
 	ssize_t n = 0;
 
 	do {
@@ -62,8 +61,6 @@ ssize_t circ_fill(int fd, struct circ_buf *circ)
 			return -1;
 		} else if (n < 0)
 			return -1;
-
-		count += n;
 
 		circ->head = (circ->head + n) & (CIRC_BUF_SIZE - 1);
 	} while (n != space);

--- a/circ_buf.c
+++ b/circ_buf.c
@@ -85,7 +85,7 @@ size_t circ_peak(struct circ_buf *circ, void *buf, size_t len)
 		tail = (tail + 1) & (CIRC_BUF_SIZE - 1);
 	}
 
-	return (void*)p - buf;
+	return p - (char *)buf;
 }
 
 size_t circ_read(struct circ_buf *circ, void *buf, size_t len)
@@ -101,5 +101,5 @@ size_t circ_read(struct circ_buf *circ, void *buf, size_t len)
 		circ->tail = (circ->tail + 1) & (CIRC_BUF_SIZE - 1);
 	}
 
-	return (void*)p - buf;
+	return p - (char *)buf;
 }

--- a/conmux.c
+++ b/conmux.c
@@ -166,7 +166,7 @@ static int registry_lookup(const char *service, struct conmux_lookup *result)
 		err(1, "failed to connect to registry");
 
 	ret = snprintf(buf, sizeof(buf), "LOOKUP service=%s\n", service);
-	if (ret >= sizeof(buf))
+	if (ret >= (int)sizeof(buf))
 		errx(1, "service name too long for registry lookup request");
 
 	n = write(fd, buf, ret + 1);
@@ -273,7 +273,7 @@ void *conmux_open(struct device *dev)
 		err(1, "failed to connect to conmux instance");
 
 	ret = snprintf(req, sizeof(req), "CONNECT id=cdba:%s to=console\n", user);
-	if (ret >= sizeof(req))
+	if (ret >= (int)sizeof(req))
 		errx(1, "unable to fit connect request in buffer");
 
 	n = write(fd, req, ret + 1);

--- a/device.c
+++ b/device.c
@@ -61,7 +61,7 @@ static void device_lock(struct device *device)
 	int n;
 
 	n = snprintf(lock, sizeof(lock), "/tmp/cdba-%s.lock", device->board);
-	if (n >= sizeof(lock))
+	if (n >= (int)sizeof(lock))
 		errx(1, "failed to build lockfile path");
 
 	fd = open(lock, O_RDONLY | O_CREAT, 0666);

--- a/device_parser.c
+++ b/device_parser.c
@@ -50,7 +50,7 @@ struct device_parser {
 static void nextsym(struct device_parser *dp)
 {
 	if (!yaml_parser_parse(&dp->parser, &dp->event)) {
-		fprintf(stderr, "device parser: error %d\n", dp->parser.error);
+		fprintf(stderr, "device parser: error %u\n", dp->parser.error);
 		exit(1);
 	}
 }
@@ -77,7 +77,7 @@ static bool expect(struct device_parser *dp, int type, char *scalar)
 		return true;
 	}
 
-	fprintf(stderr, "device parser: expected %d got %d\n", type, dp->event.type);
+	fprintf(stderr, "device parser: expected %d got %u\n", type, dp->event.type);
 	exit(1);
 }
 

--- a/ftdi-gpio.c
+++ b/ftdi-gpio.c
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "cdba-server.h"
 #include "ftdi-gpio.h"

--- a/ftdi-gpio.c
+++ b/ftdi-gpio.c
@@ -144,7 +144,7 @@ static void ftdi_gpio_parse_config(struct ftdi_gpio *ftdi_gpio, char *control_de
 
 		gpio_offset = strtoul(off, NULL, 0);
 		if (gpio_offset > 7)
-			errx(1, "GPIOs offset invalid: '%d'", gpio_offset);
+			errx(1, "GPIOs offset invalid: '%u'", gpio_offset);
 
 		if (strncmp("ACTIVE_HIGH", pol, c - pol - 1) == 0)
 			gpio_polarity = GPIO_ACTIVE_HIGH;

--- a/ftdi-gpio.c
+++ b/ftdi-gpio.c
@@ -102,7 +102,7 @@ static void ftdi_gpio_parse_config(struct ftdi_gpio *ftdi_gpio, char *control_de
 	// Interface
 	interface = c + 1;
 	if (*interface != 'A' &&
-	    *interface != 'A' &&
+	    *interface != 'B' &&
 	    *interface != 'C' &&
 	    *interface != 'D') {
 		errx(1, "Invalid interface '%c'", *interface);

--- a/list.h
+++ b/list.h
@@ -35,7 +35,7 @@
 #include <stddef.h>
 
 #define container_of(ptr, type, member) ({ \
-		const typeof(((type *)0)->member)*__mptr = (ptr);  \
+		typeof(((type *)0)->member)*__mptr = (ptr);  \
 		(type *)((char *)__mptr - offsetof(type, member)); \
 		})
 

--- a/list.h
+++ b/list.h
@@ -36,7 +36,7 @@
 
 #define container_of(ptr, type, member) ({ \
 		typeof(((type *)0)->member)*__mptr = (ptr);  \
-		(type *)((char *)__mptr - offsetof(type, member)); \
+		(type *)(void *)((char *)__mptr - offsetof(type, member)); \
 		})
 
 struct list_head {


### PR DESCRIPTION
Enable several warnings and fix them. Enable also -Werror so any new warnings will be always spotted.