### PR TITLE
schema: Allow Fastboot serial numbers up to 16 characters

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -26,7 +26,7 @@ properties:
         fastboot:
           description: fastboot id
           type: string
-          pattern: "^[0-9a-f]{8}$"
+          pattern: "^[0-9a-f]{8,16}$"
 
         fastboot_set_active:
           description: run fastboot set active before each boot, slot can be selected


### PR DESCRIPTION
WinLink e850 board reports Fastboot ID/serial of "00000b66ce9c23e0" and fastboot sources [1] allow up to 256 bytes, so grow the pattern to at least 16 characters:

[1] https://android.googlesource.com/platform/system/core/+/refs/heads/android16-release/fastboot/usb.h#54