### PR TITLE
cdba: add per-board power key press duration

### DIFF
--- a/device.c
+++ b/device.c
@@ -213,7 +213,10 @@ static void device_tick(void *data)
 		device_key(device, DEVICE_KEY_POWER, true);
 
 		device->state = DEVICE_STATE_RELEASE_PWR;
-		watch_timer_add(100, device_tick, device);
+		if (device->power_key_press_ms)
+			watch_timer_add(device->power_key_press_ms, device_tick, device);
+		else
+			watch_timer_add(100, device_tick, device);
 		break;
 	case DEVICE_STATE_RELEASE_PWR:
 		/* Release power key */

--- a/device.h
+++ b/device.h
@@ -45,6 +45,7 @@ struct device {
 	bool power_always_on;
 	struct fastboot *fastboot;
 	unsigned int fastboot_key_timeout;
+	unsigned int power_key_press_ms;
 	int state;
 	bool has_power_key;
 

--- a/device_parser.c
+++ b/device_parser.c
@@ -203,6 +203,8 @@ static void parse_board(struct device_parser *dp)
 			dev->description = strdup(value);
 		} else if (!strcmp(key, "fastboot_key_timeout")) {
 			dev->fastboot_key_timeout = strtoul(value, NULL, 10);
+		} else if (!strcmp(key, "power_key_press_ms")) {
+			dev->power_key_press_ms = MAX(100, strtoul(value, NULL, 10));
 		} else if (!strcmp(key, "usb_always_on")) {
 			dev->usb_always_on = !strcmp(value, "true");
 		} else if (!strcmp(key, "ppps_path")) {

--- a/schema.yaml
+++ b/schema.yaml
@@ -49,6 +49,11 @@ properties:
           type: integer
           minimum: 1
 
+        power_key_press_ms:
+          description: duration of the power key press in milliseconds
+          type: integer
+          minimum: 100
+
         cdba:
           description: CDB Assist device path
           $ref: "#/$defs/device_path"


### PR DESCRIPTION
On some Alpaca boards the power key needs to be pressed for longer than the default duration, otherwise the board powers down automatically.

Add a 'power_key_press_ms' board configuration property to allow specifying the duration in milliseconds.