### PR TITLE
ssh tunnel can time out when idle

### DIFF
--- a/cdba.c
+++ b/cdba.c
@@ -130,7 +130,10 @@ static int fork_ssh(const char *host, const char *cmd, int *pipes)
 		close(piped_stderr[1]);
 
 		if (host) {
-			execlp("ssh", "ssh", host, cmd, NULL);
+			execlp("ssh", "ssh",
+			       "-o", "ServerAliveInterval=30",
+			       "-o", "ServerAliveCountMax=3",
+			       host, cmd, NULL);
 			err(1, "launching ssh failed");
 		} else {
 			execlp(cmd, cmd, NULL);


### PR DESCRIPTION
Remote CDBA sessions currently rely on users configuring ServerAliveInterval in ~/.ssh/config to keep the underlying ssh connection active.

Pass ServerAliveInterval and ServerAliveCountMax directly when the client launches ssh so otherwise idle tunnels stay alive and ssh can detect dead connections.